### PR TITLE
Fix Davide-sd/shutdown_or_switch#11

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -33,7 +33,7 @@
     <entry name="showSuspend" type="Bool">
         <default>false</default>
     </entry>
-    <entry name="showHybernate" type="Bool">
+    <entry name="showHibernate" type="Bool">
         <default>false</default>
     </entry>
     <entry name="showNewSession" type="Bool">

--- a/package/contents/ui/configGeneral.qml
+++ b/package/contents/ui/configGeneral.qml
@@ -23,7 +23,7 @@ KCM.SimpleKCM {
     property alias cfg_showRestart: showRestart.checked
     property alias cfg_showShutdown: showShutdown.checked
     property alias cfg_showSuspend: showSuspend.checked
-    property alias cfg_showHybernate: showHybernate.checked
+    property alias cfg_showHibernate: showHibernate.checked
     property alias cfg_showUsers: showUsers.checked
     property alias cfg_showText: showText.checked
     property alias cfg_icon: icon.text
@@ -167,8 +167,8 @@ KCM.SimpleKCM {
         }
 
         QtControls.CheckBox {
-            id: showHybernate
-            text: i18nc("@option:check", "Hybernate")
+            id: showHibernate
+            text: i18nc("@option:check", "Hibernate")
         }
 
         QtControls.CheckBox {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -30,7 +30,7 @@ PlasmoidItem {
     readonly property bool showRestart: Plasmoid.configuration.showRestart
     readonly property bool showShutdown: Plasmoid.configuration.showShutdown
     readonly property bool showSuspend: Plasmoid.configuration.showSuspend
-    readonly property bool showHybernate: Plasmoid.configuration.showHybernate
+    readonly property bool showHibernate: Plasmoid.configuration.showHibernate
     readonly property bool showNewSession: Plasmoid.configuration.showNewSession
     readonly property bool showUsers: Plasmoid.configuration.showUsers
     readonly property bool showText: Plasmoid.configuration.showText
@@ -242,10 +242,10 @@ PlasmoidItem {
             }
 
             ActionListDelegate {
-                id: hybernateButton
-                text: showText ? i18nc("@action", "Hybernate") : ""
+                id: hibernateButton
+                text: showText ? i18nc("@action", "Hibernate") : ""
                 icon.name: "system-suspend-hibernate"
-                visible: sm.canSuspendThenHibernate && showHybernate
+                visible: sm.canSuspendThenHibernate && showHibernate
                 onClicked: sm.suspendThenHibernate()
             }
         }


### PR DESCRIPTION
The correct spelling is indeed "hibernate", as confirmed by:
- [Collins Dictionary](https://www.collinsdictionary.com/dictionary/english/hibernate)
- [Cambridge Dictionary](https://dictionary.cambridge.org/dictionary/english/hibernate)
- [Wikipedia](https://en.wikipedia.org/wiki/Hibernation_(computing))
- [ArchWiki](https://wiki.archlinux.org/title/Power_management/Suspend_and_hibernate)